### PR TITLE
Require axios from installed modules

### DIFF
--- a/drivers/http/axios.js
+++ b/drivers/http/axios.js
@@ -1,13 +1,13 @@
-let axios = require('axios')
+let $axios = require('axios')
 
 module.exports = {
   _init: function (Vue) {
-    if (!axios) {
+    if (!$axios) {
       console.warn('@deveodk/vue-error-tracker : axios must be set before this plugin is used.')
     }
   },
   _interceptor: function (Vue, code, errorCb) {
-    if (axios) {
+    if ($axios) {
       axios.interceptors.response.use(function (response) {
         code(response)
         return response

--- a/drivers/http/axios.js
+++ b/drivers/http/axios.js
@@ -1,18 +1,20 @@
+let axios = require('axios')
+
 module.exports = {
-    _init: function (Vue) {
-        if (!Vue.prototype.axios) {
-            console.warn('@deveodk/vue-error-tracker : axios must be set before this plugin is used.')
-        }
-    },
-    _interceptor: function (Vue, code, errorCb) {
-        Vue.prototype.axios.interceptors.response.use(function (response) {
-            // Do something with response data
-            code(response)
-            return response
-        }, function (error) {
-            errorCb(error.response)
-            // Do something with response error
-            return Promise.reject(error);
-        })
+  _init: function (Vue) {
+    if (!axios) {
+      console.warn('@deveodk/vue-error-tracker : axios must be set before this plugin is used.')
     }
+  },
+  _interceptor: function (Vue, code, errorCb) {
+    if (axios) {
+      axios.interceptors.response.use(function (response) {
+        code(response)
+        return response
+      }, function (error) {
+        errorCb(error.response)
+        return Promise.reject(error);
+      })
+    }
+  }
 }

--- a/drivers/http/vueResource.js
+++ b/drivers/http/vueResource.js
@@ -1,11 +1,11 @@
 module.exports = {
   _init: function (Vue) {
-    if (!Vue.http) {
+    if (!Vue.prototype.http) {
       console.warn('@deveodk/vue-error-tracker : vue-resource must be set before this plugin is used.')
     }
   },
   _interceptor: function (Vue, code) {
-    Vue.http.interceptors.push(function (request, next) {
+    Vue.prototype.http.interceptors.push(function (request, next) {
       next(function (response) {
         code(response)
       })

--- a/drivers/http/vueResource.js
+++ b/drivers/http/vueResource.js
@@ -1,14 +1,14 @@
 module.exports = {
-    _init: function (Vue) {
-        if (!Vue.prototype.http) {
-            console.warn('@deveodk/vue-error-tracker : vue-resource must be set before this plugin is used.')
-        }
-    },
-    _interceptor: function (Vue, code) {
-        Vue.prototype.http.interceptors.push(function (request, next) {
-                next(function (response) {
-                    code(response)
-                })
-        })
+  _init: function (Vue) {
+    if (!Vue.http) {
+      console.warn('@deveodk/vue-error-tracker : vue-resource must be set before this plugin is used.')
     }
+  },
+  _interceptor: function (Vue, code) {
+    Vue.http.interceptors.push(function (request, next) {
+      next(function (response) {
+        code(response)
+      })
+    })
+  }
 }


### PR DESCRIPTION
Hi!

Thispull request contains very small changes to use require `axios` instead of forcing user to pollute `vue.prototype`. 